### PR TITLE
Character Length for passHash is too small

### DIFF
--- a/docs/mysqlDBsetup.md
+++ b/docs/mysqlDBsetup.md
@@ -27,8 +27,8 @@ mysql -u admin -p ProjectDB
 ```
 create table if not exists Users(
     id int not null auto_increment,
-    username varchar(20) not null,
-    email varchar(100) not null,
+    username varchar(30) not null,
+    email varchar(255) not null,
     passHash varchar(255) not null,
     primary key(id),
     unique (email),
@@ -38,7 +38,7 @@ create table if not exists Users(
 OR
 
 ```
-create table if not exists Users(id int not null auto_increment, username varchar(20) not null, email varchar(100) not null, passHash varchar(255) not null, primary key(id), unique (email), unique (username));
+create table if not exists Users(id int not null auto_increment, username varchar(30) not null, email varchar(255) not null, passHash varchar(255) not null, primary key(id), unique (email), unique (username));
 ```
 
 select user, host, authentication_string from mysql.user; //NOT NEEDED


### PR DESCRIPTION
# Character Length for passHash is too small
Changed the character length for the passHash to 255. 

## Reason
I searched up on stack overflow that a password hash should have 255 characters to store it in the database since it is a long variable. It is on 9-character-length-for-passhash-is-too-small branch. I also increased character length for the email attribute since emails can be very long. I slightly increase character length of the username in case a user has a long username.

## Tasks Done
- changed passHash data type to varchar(255)
- changed username data type to varchar(30)
- changed email data type to varchar(255)