### PR TITLE
Redirect to index.php

### DIFF
--- a/electrik/002-electrik-ssl.conf
+++ b/electrik/002-electrik-ssl.conf
@@ -19,7 +19,7 @@
 	SSLEngine on
 	SSLCertificateKeyFile /etc/ssl/private/www.electrik.com.key
 	SSLCertificateFile /etc/ssl/certs/www.electrik.com.crt 
-	
+
 	ErrorLog ${APACHE_LOG_DIR}/sample_error.log
 	CustomLog ${APACHE_LOG_DIR}/sample_access.log combined
 


### PR DESCRIPTION
The https://www.electrik.com proxy website redirects to index.php as its index page.

Replace the apache config
```
sudo cp electrik/002-electrik-ssl.conf /etc/apache2/sites-available/
```

Restart apache2
```
sudo systemctl restart apache2
```